### PR TITLE
PR: Invert order git diff blobs in commited mode

### DIFF
--- a/ciocheck/vcs.py
+++ b/ciocheck/vcs.py
@@ -125,7 +125,7 @@ class GitDiffTool(DiffToolBase):
         ]
 
         if mode == COMMITED_MODE:
-            command.append("{branch}...HEAD".format(branch=branch))
+            command.append("HEAD...{branch}".format(branch=branch))
         elif mode == STAGED_MODE:
             command.append('--cached')
 


### PR DESCRIPTION
Fixes:  #29

-----------------

As the comparison was inverted, git diff was returning **deleted** and modified lines, instead of **added** and modified lines.